### PR TITLE
Multi section support

### DIFF
--- a/src/Meta.php
+++ b/src/Meta.php
@@ -214,6 +214,12 @@ class Meta
             }
         }
 
+        if (empty($this->getSections()) && count($meta->getSections())) {
+            foreach ($meta->getSections() as $section) {
+                $this->addSection($section);
+            }
+        }
+
         if (!$this->getKeywords() && $meta->getKeywords()) {
             $this->setKeywords($meta->getKeywords());
         }
@@ -240,10 +246,6 @@ class Meta
 
         if (!$this->getOgImage() && $meta->getOgImage()) {
             $this->setOgImage($meta->getOgImage());
-        }
-
-        if (!$this->getSection() && $meta->getSection()) {
-            $this->setSection($meta->getSection());
         }
 
         if (!$this->getPublishedTime() && $meta->getPublishedTime()) {

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -61,14 +61,6 @@ class Meta
         return $this;
     }
 
-    public function getAuthor(): ?string
-    {
-        if (count($this->authors)) {
-            return $this->authors[0]['name'];
-        }
-        return null;
-    }
-
     public function getAuthors(): array
     {
         return $this->authors;

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -64,7 +64,7 @@ class Meta
     public function getAuthor(): ?string
     {
         if (count($this->authors)) {
-            return $this->authors[0];
+            return $this->authors[0]['name'];
         }
         return null;
     }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -27,7 +27,7 @@ class Meta
 
     private $ogImage;
 
-    private $section;
+    private $sections;
 
     private $publishedTime;
 
@@ -151,15 +151,15 @@ class Meta
         return $this->ogImage;
     }
 
-    public function setSection(string $section): Meta
+    public function addSection(string $section): Meta
     {
         $this->section = $section;
         return $this;
     }
 
-    public function getSection(): ?string
+    public function getSections(): array
     {
-        return $this->section;
+        return $this->sections;
     }
 
     public function setPublishedTime($publishedTime): Meta

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -153,7 +153,7 @@ class Meta
 
     public function addSection(string $section): Meta
     {
-        $this->section = $section;
+        $this->sections[] = $section;
         return $this;
     }
 

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -27,7 +27,7 @@ class Meta
 
     private $ogImage;
 
-    private $sections;
+    private $sections = [];
 
     private $publishedTime;
 

--- a/src/Parser/OgParser.php
+++ b/src/Parser/OgParser.php
@@ -46,7 +46,7 @@ class OgParser implements ParserInterface
 
         preg_match('/<meta.*property=\"article:section\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
         if ($matches) {
-            $meta->setSection(htmlspecialchars_decode($matches[1]));
+            $meta->addSection(htmlspecialchars_decode($matches[1]));
         }
 
         preg_match('/<meta.*property=\"article:published_time\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);

--- a/src/Parser/OgParser.php
+++ b/src/Parser/OgParser.php
@@ -34,7 +34,10 @@ class OgParser implements ParserInterface
 
         preg_match('/<meta.*name=\"author\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
         if ($matches) {
-            $meta->addAuthor(htmlspecialchars_decode($matches[1]));
+            $meta->addAuthor([
+                'id' => null,
+                'name' => htmlspecialchars_decode($matches[1]),
+            ]);
         }
 
         // maybe in future - optimalize to one preg_match for all og:*

--- a/src/Parser/SchemaParser.php
+++ b/src/Parser/SchemaParser.php
@@ -18,50 +18,52 @@ class SchemaParser implements ParserInterface
             return $meta;
         }
         
-        $schema = json_decode($matches[1][0]);
+        $schema = json_decode($matches[1][0], true);
         if (!$schema) {
             return $meta;
         }
 
         // author
-        $denniknAuthors = false;
-        if (isset($schema->author) && !is_array($schema->author)) {
-            $schema->author = [$schema->author];
+        if (isset($schema['author']) && !is_array($schema['author'])) {
+            $schema['author'] = [$schema['author']];
         }
-        foreach ($schema->author as $author) {
-            if (isset($author->name)) {
-                $meta->addAuthor($author->name);
-            } else {
-                $meta->addAuthor($author);
-            }
+        foreach ($schema['author'] ?? [] as $author) {
+            $meta->addAuthor([
+                'id' => $author['@id'] ?? null,
+                'name' => $author['name'] ?? null,
+            ]);
         }
 
-        if (isset($schema->headline)) {
-            $meta->setTitle($schema->headline);
+        // section
+        if (isset($schema['articleSection']) && !is_array($schema['articleSection'])) {
+            $schema['articleSection'] = [$schema['articleSection']];
+        }
+        foreach ($schema['articleSection'] ?? [] as $section) {
+            $meta->addSection($section);
         }
 
-        if (isset($schema->description)) {
-            $meta->setDescription($schema->description);
+        if (isset($schema['headline'])) {
+            $meta->setTitle($schema['headline']);
         }
 
-        if (isset($schema->image->url)) {
-            $meta->setOgImage($schema->image->url);
+        if (isset($schema['description'])) {
+            $meta->setDescription($schema['description']);
         }
 
-        if (isset($schema->url)) {
-            $meta->setOgUrl($schema->url);
+        if (isset($schema['image']['url'])) {
+            $meta->setOgImage($schema['image']['url']);
         }
 
-        if (isset($schema->articleSection)) {
-            $meta->setSection($schema->articleSection);
+        if (isset($schema['url'])) {
+            $meta->setOgUrl($schema['url']);
         }
 
-        if (isset($schema->datePublished)) {
-            $meta->setPublishedTime($schema->datePublished);
+        if (isset($schema['datePublished'])) {
+            $meta->setPublishedTime($schema['datePublished']);
         }
 
-        if (isset($schema->dateModified)) {
-            $meta->setModifiedTime($schema->dateModified);
+        if (isset($schema['dateModified'])) {
+            $meta->setModifiedTime($schema['dateModified']);
         }
 
         return $meta;

--- a/tests/ScraperTest.php
+++ b/tests/ScraperTest.php
@@ -39,7 +39,7 @@ EOT;
         $this->assertEquals('Mega site name', $meta->getOgSiteName());
         $this->assertEquals('Og title nadpis', $meta->getOgTitle());
         $this->assertEquals('https://obrazok.jpg', $meta->getOgImage());
-        $this->assertEquals('Ekonomika', $meta->getSection());
+        $this->assertEquals('Ekonomika', $meta->getSections()[0]);
         $this->assertEquals('12.10.2015 12:40:27', $meta->getPublishedTime()->format('d.m.Y H:i:s'));
         $this->assertEquals('13.11.2016 13:21:42', $meta->getModifiedTime()->format('d.m.Y H:i:s'));
         $this->assertEquals('Keyword1,Keyword2', $meta->getKeywords());
@@ -57,7 +57,7 @@ EOT;
         $this->assertNull($meta->getOgUrl());
         $this->assertNull($meta->getOgSiteName());
         $this->assertNull($meta->getOgImage());
-        $this->assertNull($meta->getSection());
+        $this->assertEmpty($meta->getSections());
     }
 
     public function testMoreAttributes()
@@ -98,7 +98,7 @@ EOT;
     {
         $data = <<<EOT
         text
-        <script id="schema" type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","url":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/","position":1325802,"headline":"Veľa pohybu a málo mäsa. Päť miest, kde ľudia žijú najdlhšie, ohrozuje westernizácia","description":"Čo spája miesta na Zemi, kde ľudia žijú najdlhšie?","articleSection":"Svet,Veda","datePublished":"2018-12-15T19:00:26+00:00","dateModified":"2018-12-17T00:28:43+00:00","wordCount":1650,"mainEntityOfPage":{"@type":"WebPage","@id":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/"},"author":[{"@type":"Person","@id":"495","name":"Tomáš Vasilko"}],"publisher":{"@type":"Organization","name":"Denník N","logo":{"@type":"ImageObject","url":"https://dennikn.sk/wp-content/themes/dn-2-sk/dennikn-60x60.png","width":60,"height":60}},"image":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg","width":756,"height":427,"thumbnail":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg?fm=jpg&q=80&w=360&h=200&fit=crop","width":360,"height":200}},"isAccessibleForFree":false,"hasPart":[{"@type":"WebPageElement","isAccessibleForFree":"False","cssSelector":".a_single"}]}</script>
+        <script id="schema" type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","url":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/","position":1325802,"headline":"Veľa pohybu a málo mäsa. Päť miest, kde ľudia žijú najdlhšie, ohrozuje westernizácia","description":"Čo spája miesta na Zemi, kde ľudia žijú najdlhšie?","articleSection":["Svet","Veda"],"datePublished":"2018-12-15T19:00:26+00:00","dateModified":"2018-12-17T00:28:43+00:00","wordCount":1650,"mainEntityOfPage":{"@type":"WebPage","@id":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/"},"author":[{"@type":"Person","@id":"495","name":"Tomáš Vasilko"}],"publisher":{"@type":"Organization","name":"Denník N","logo":{"@type":"ImageObject","url":"https://dennikn.sk/wp-content/themes/dn-2-sk/dennikn-60x60.png","width":60,"height":60}},"image":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg","width":756,"height":427,"thumbnail":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg?fm=jpg&q=80&w=360&h=200&fit=crop","width":360,"height":200}},"isAccessibleForFree":false,"hasPart":[{"@type":"WebPageElement","isAccessibleForFree":"False","cssSelector":".a_single"}]}</script>
         text
 EOT;
 
@@ -113,7 +113,7 @@ EOT;
 
         $this->assertEquals('https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/', $meta->getOgUrl());
 
-        $this->assertEquals('Svet,Veda', $meta->getSection());
+        $this->assertEquals(['Svet', 'Veda'], $meta->getSections());
 
         $this->assertEquals(null, $meta->getOgTitle());
 
@@ -137,7 +137,7 @@ EOT;
         <meta property="og:description" content="Čo spája miesta na Zemi, kde ľudia žijú najdlhšie? OG">
         <meta property="og:title" content="Veľa pohybu a&nbsp;málo mäsa. Päť miest, kde ľudia žijú najdlhšie, ohrozuje westernizácia OG">
 
-        <script id="schema" type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","url":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/","position":1325802,"headline":"Veľa pohybu a málo mäsa. Päť miest, kde ľudia žijú najdlhšie, ohrozuje westernizácia","description":"Čo spája miesta na Zemi, kde ľudia žijú najdlhšie?","articleSection":"Svet,Veda","datePublished":"2018-12-15T19:00:26+00:00","dateModified":"2018-12-17T00:28:43+00:00","wordCount":1650,"mainEntityOfPage":{"@type":"WebPage","@id":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/"},"author":[{"@type":"Person","@id":"495","name":"Tomáš Vasilko"}],"publisher":{"@type":"Organization","name":"Denník N","logo":{"@type":"ImageObject","url":"https://dennikn.sk/wp-content/themes/dn-2-sk/dennikn-60x60.png","width":60,"height":60}},"image":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg","width":756,"height":427,"thumbnail":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg?fm=jpg&q=80&w=360&h=200&fit=crop","width":360,"height":200}},"isAccessibleForFree":false,"hasPart":[{"@type":"WebPageElement","isAccessibleForFree":"False","cssSelector":".a_single"}]}</script>
+        <script id="schema" type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","url":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/","position":1325802,"headline":"Veľa pohybu a málo mäsa. Päť miest, kde ľudia žijú najdlhšie, ohrozuje westernizácia","description":"Čo spája miesta na Zemi, kde ľudia žijú najdlhšie?","articleSection":["Svet","Veda"],"datePublished":"2018-12-15T19:00:26+00:00","dateModified":"2018-12-17T00:28:43+00:00","wordCount":1650,"mainEntityOfPage":{"@type":"WebPage","@id":"https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/"},"author":[{"@type":"Person","@id":"495","name":"Tomáš Vasilko"}],"publisher":{"@type":"Organization","name":"Denník N","logo":{"@type":"ImageObject","url":"https://dennikn.sk/wp-content/themes/dn-2-sk/dennikn-60x60.png","width":60,"height":60}},"image":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg","width":756,"height":427,"thumbnail":{"@type":"ImageObject","url":"https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg?fm=jpg&q=80&w=360&h=200&fit=crop","width":360,"height":200}},"isAccessibleForFree":false,"hasPart":[{"@type":"WebPageElement","isAccessibleForFree":"False","cssSelector":".a_single"}]}</script>
 EOT;
 
         $scraper = new Scraper();
@@ -154,7 +154,7 @@ EOT;
 
         $this->assertEquals('https://dennikn.sk/1325802/vela-pohybu-a-malo-masa-pat-miest-kde-ludia-ziju-najdlhsie-ohrozuje-westernizacia/', $meta->getOgUrl());
 
-        $this->assertEquals('Svet,Veda', $meta->getSection());
+        $this->assertEquals(['Svet', 'Veda'], $meta->getSections());
 
         $this->assertEquals('Veľa pohybu a&nbsp;málo mäsa. Päť miest, kde ľudia žijú najdlhšie, ohrozuje westernizácia OG', $meta->getOgTitle());
 

--- a/tests/ScraperTest.php
+++ b/tests/ScraperTest.php
@@ -31,7 +31,7 @@ EOT;
 
         $this->assertEquals('Page title', $meta->getTitle());
         $this->assertEquals('Default page description', $meta->getDescription());
-        $this->assertEquals('Jozko Pucik', $meta->getAuthor());
+        $this->assertEquals([['id' => null, 'name' => 'Jozko Pucik']], $meta->getAuthors());
 
         $this->assertEquals('article', $meta->getOgType());
         $this->assertEquals('Silny popis', $meta->getOgDescription());
@@ -39,7 +39,7 @@ EOT;
         $this->assertEquals('Mega site name', $meta->getOgSiteName());
         $this->assertEquals('Og title nadpis', $meta->getOgTitle());
         $this->assertEquals('https://obrazok.jpg', $meta->getOgImage());
-        $this->assertEquals('Ekonomika', $meta->getSections()[0]);
+        $this->assertEquals(['Ekonomika'], $meta->getSections());
         $this->assertEquals('12.10.2015 12:40:27', $meta->getPublishedTime()->format('d.m.Y H:i:s'));
         $this->assertEquals('13.11.2016 13:21:42', $meta->getModifiedTime()->format('d.m.Y H:i:s'));
         $this->assertEquals('Keyword1,Keyword2', $meta->getKeywords());
@@ -51,7 +51,7 @@ EOT;
         $meta = $scraper->parse("sdsadipojhafidsjf dsf ", [new \Tomaj\Scraper\Parser\OgParser()]);
         $this->assertNull($meta->getTitle());
         $this->assertNull($meta->getDescription());
-        $this->assertNull($meta->getAuthor());
+        $this->assertEmpty($meta->getAuthors());
         $this->assertNull($meta->getOgType());
         $this->assertNull($meta->getOgDescription());
         $this->assertNull($meta->getOgUrl());
@@ -119,8 +119,6 @@ EOT;
 
         $this->assertEquals('https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg', $meta->getOgImage());
 
-        $this->assertEquals('Tomáš Vasilko', $meta->getAuthor());
-
         $this->assertEquals([['id' => 495, 'name' => 'Tomáš Vasilko']], $meta->getAuthors());
 
         $this->assertEquals(new \DateTime('@' . strtotime('2018-12-15T19:00:26+00:00')), $meta->getPublishedTime());
@@ -159,8 +157,6 @@ EOT;
         $this->assertEquals('Veľa pohybu a&nbsp;málo mäsa. Päť miest, kde ľudia žijú najdlhšie, ohrozuje westernizácia OG', $meta->getOgTitle());
 
         $this->assertEquals('https://img.projektn.sk/wp-static/2018/12/XkJ05Z9kQFZoy6hlKrEcj8U3Aevn1wfu-6r8OMz0Ah4.jpg', $meta->getOgImage());
-
-        $this->assertEquals('Tomáš Vasilko', $meta->getAuthor());
 
         $this->assertEquals([['id' => 495, 'name' => 'Tomáš Vasilko']], $meta->getAuthors());
 

--- a/tests/ScraperTest.php
+++ b/tests/ScraperTest.php
@@ -121,7 +121,7 @@ EOT;
 
         $this->assertEquals('Tomáš Vasilko', $meta->getAuthor());
 
-        $this->assertEquals(['Tomáš Vasilko'], $meta->getAuthors());
+        $this->assertEquals([['id' => 495, 'name' => 'Tomáš Vasilko']], $meta->getAuthors());
 
         $this->assertEquals(new \DateTime('@' . strtotime('2018-12-15T19:00:26+00:00')), $meta->getPublishedTime());
 
@@ -162,7 +162,7 @@ EOT;
 
         $this->assertEquals('Tomáš Vasilko', $meta->getAuthor());
 
-        $this->assertEquals(['Tomáš Vasilko'], $meta->getAuthors());
+        $this->assertEquals([['id' => 495, 'name' => 'Tomáš Vasilko']], $meta->getAuthors());
 
         $this->assertEquals(new \DateTime('@' . strtotime('2018-12-15T19:00:26+00:00')), $meta->getPublishedTime());
 


### PR DESCRIPTION
* Added support for multi-sections
  * Added `getSections()` getter
  * Did not kept `getSection()` at all, client should change the implementation after updating
* Decoding json schema in `SchemaParser` as array to be able to read `@id` field
* Author is now being returned as array of arrays instead of arrays of strings
  
  Previously
  ```php
  [
    "First Author",
    "Second Author",
  ]
  ```

  Now
  ```php
  [
    ["name" => "First Author", "id" => "31"],
    ["name" => "Second Author", "id" => "32"],
  ]
  ```

  This is so the client can search parsed authors based on their ID, not just their names.