### PR TITLE
Bugfixing undefined offset caused by no match

### DIFF
--- a/src/Parser/SchemaParser.php
+++ b/src/Parser/SchemaParser.php
@@ -14,7 +14,7 @@ class SchemaParser implements ParserInterface
         $matches = [];
         preg_match_all('/<script id="schema" type="application\/ld\+json">(.*?)<\/script>/', $content, $matches);
 
-        if (!$matches) {
+        if (!isset($matches[1][0])) {
             return $meta;
         }
         

--- a/tests/ScraperTest.php
+++ b/tests/ScraperTest.php
@@ -48,7 +48,10 @@ EOT;
     public function testEmpty()
     {
         $scraper = new Scraper();
-        $meta = $scraper->parse("sdsadipojhafidsjf dsf ", [new \Tomaj\Scraper\Parser\OgParser()]);
+        $meta = $scraper->parse("sdsadipojhafidsjf dsf ", [
+            new \Tomaj\Scraper\Parser\OgParser(),
+            new \Tomaj\Scraper\Parser\SchemaParser()
+        ]);
         $this->assertNull($meta->getTitle());
         $this->assertNull($meta->getDescription());
         $this->assertNull($meta->getAuthor());


### PR DESCRIPTION
For URLs with no JSON schema, the $matches array would have two elements,
both of them array with no elements inside. The original condition
would let it pass even if nothing was actually matched.