### PR TITLE
Add guzzle options to scraper

### DIFF
--- a/src/Parser/OgParser.php
+++ b/src/Parser/OgParser.php
@@ -24,64 +24,64 @@ class OgParser implements ParserInterface
             $meta->setTitle(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*name=\"description\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*name=\"description\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setDescription(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*name=\"keywords\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*name=\"keywords\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setKeywords(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*name=\"author\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*name=\"author\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->addAuthor(new Author(null, htmlspecialchars_decode($matches[1])));
         }
 
         // maybe in future - optimalize to one preg_match for all og:*
 
-        preg_match('/<meta.*property=\"og:title\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"og:title\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setOgTitle(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*property=\"article:section\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"article:section\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->addSection(new Section(null, htmlspecialchars_decode($matches[1])));
         }
 
-        preg_match('/<meta.*property=\"article:published_time\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"article:published_time\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setPublishedTime(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*property=\"article:modified_time\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"article:modified_time\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setModifiedTime(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*property=\"og:description\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"og:description\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setOgDescription(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*property=\"og:type\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"og:type\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setOgType(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*property=\"og:url\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"og:url\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setOgUrl(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*property=\"og:site_name\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"og:site_name\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setOgSiteName(htmlspecialchars_decode($matches[1]));
         }
 
-        preg_match('/<meta.*property=\"og:image\".*content=\"(.+)\"\s*[\/]*\>/Uis', $content, $matches);
+        preg_match('/<meta.*property=\"og:image\".*content=\"(.+)\"/Uis', $content, $matches);
         if ($matches) {
             $meta->setOgImage(htmlspecialchars_decode($matches[1]));
         }

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -8,16 +8,23 @@ use GuzzleHttp\Client;
 class Scraper
 {
     protected $userAgent = 'Tomaj\Scraper';
-
+    protected $guzzleOptions = [
+        'connect_timeout' => 5
+    ]
     private $body;
+    
+    public function __construct(array $guzzleOptions = [])
+    {
+        $this->guzzleOptions = array_merge($this->guzzleOptions, $guzzleOptions);
+    }
 
     /**
      * @throws \GuzzleHttp\Exception\RequestException
      */
-    public function parseUrl(string $url, array $parsers, int $timeout = 5): Meta
+    public function parseUrl(string $url, array $parsers): Meta
     {
         $client = new Client();
-        $res = $client->get($url, ['connect_timeout' => $timeout]);
+        $res = $client->get($url, $this->guzzleOptions);
 
         $this->body = (string) $res->getBody();
 

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -7,10 +7,13 @@ use GuzzleHttp\Client;
 
 class Scraper
 {
-    protected $userAgent = 'Tomaj\Scraper';
     protected $guzzleOptions = [
-        'connect_timeout' => 5
-    ]
+        'connect_timeout' => 5,
+        'headers' => [
+            'User-Agent' => 'Tomaj\Scraper'
+        ]
+    ];
+    
     private $body;
     
     public function __construct(array $guzzleOptions = [])

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -26,8 +26,8 @@ class Scraper
      */
     public function parseUrl(string $url, array $parsers): Meta
     {
-        $client = new Client();
-        $res = $client->get($url, $this->guzzleOptions);
+        $client = new Client($this->guzzleOptions);
+        $res = $client->get($url);
 
         $this->body = (string) $res->getBody();
 

--- a/tests/ScraperTest.php
+++ b/tests/ScraperTest.php
@@ -97,6 +97,19 @@ EOT;
         $this->assertEquals('https://static01.nyt.com/images/icons/t_logo_291_black.png', $meta->getOgImage());
     }
 
+    public function testNonStandardAttributes() {
+        $data = <<<EOT
+        <html lang="en"><head><meta charSet="utf-8" class="next-head" /><meta http-equiv="x-ua-compatible" content="ie=edge" class="next-head" /><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" class="next-head" /><link rel="preconnect" href="https://files.testsite.com" class="next-head" /><link rel="preconnect" href="//www.googletagmanager.com" class="next-head" /><meta property="og:image" content="https://testsite.com/static/cloud/img/splash_600x315_1.png?_=7f9e1cc" class="next-head" /><meta property="og:image:type" content="image/png" class="next-head" /><meta property="og:image:width" content="600" class="next-head" /><meta property="og:image:height" content="315" class="next-head" /><meta property="og:site_name" content="TestSite" class="next-head" /><meta property="og:type" content="website" class="next-head" /><meta name="twitter:card" content="summary_large_image" class="next-head" /><meta name="apple-itunes-app" content="app-id=128210709876" class="next-head" /><meta property="og:url" content="https://testsite.com/" class="next-head" /><link rel="canonical" href="https://testsite.com/" class="next-head" /><link rel="manifest" href="/manifest.json" class="next-head" /><meta name="description" content="Description for TestSite" class="next-head" /><meta property="og:description" my-attribute="foo" content="Description for TestSite" data-attribute="test" class="next-head" />
+EOT;
+
+        $scraper = new Scraper();
+        $meta = $scraper->parse($data, [new \Tomaj\Scraper\Parser\OgParser()]);
+        $this->assertEquals('website', $meta->getOgType());
+        $this->assertEquals('Description for TestSite', $meta->getOgDescription());
+        $this->assertEquals('https://testsite.com/', $meta->getOgUrl());
+        $this->assertEquals('https://testsite.com/static/cloud/img/splash_600x315_1.png?_=7f9e1cc', $meta->getOgImage());
+    }
+
     public function testSchemaParser()
     {
         $data = <<<EOT


### PR DESCRIPTION
I have added a constructor to Scraper which allows passing options for the Guzzle http client. There are two default options (connect_timeout and User-Agent)

The scraper can now be instantiated with options for guzzle:

`$scraper = new Scraper(
                ['headers' =>
                    ['User-Agent' => 'facebookexternalhit/1.1']
                ]
            );`